### PR TITLE
feat: Support timeFilter query macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com) and follows semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- Added the ability to use "__timeFilter" for query macros
+
 ## [3.5.0] - 2024-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ However, as each macro needs to be re-implemented from scratch, only the followi
 supported. Other macros (that you might expect from other SQL databases) are not supported by the
 plugin (yet).
 
+### $__timeFilter(timestampColumnName)
+
+Example: `$__timeFilter(timestamp)`
+
+Will be replaced by an expression that evaluates to true if a timestamp is in
+the time range specified in the grafana user interface.
+
 ### $__unixEpochGroupSeconds(unixEpochColumnName, intervalInSeconds)
 
 Example: `$__unixEpochGroupSeconds("time", 10)`

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -27,6 +27,7 @@ type queryConfigStruct struct {
 	QueryType   string
 	FinalQuery  string
 
+	TimeRange                 backend.TimeRange
 	ShouldFillValues          bool
 	FillInterval              int
 	FillValuesTimeColumnIndex int
@@ -353,6 +354,7 @@ func query(dataQuery backend.DataQuery, config pluginConfig, ctx context.Context
 		FinalQuery:                qm.QueryText,
 		TimeColumns:               qm.TimeColumns,
 		QueryType:                 dataQuery.QueryType,
+		TimeRange:                 dataQuery.TimeRange,
 		FillValuesTimeColumnIndex: -1,
 	}
 


### PR DESCRIPTION
Grafana is _really_ unresponsive when using this plugin for large datasets. Implementing the [`__timeFilter` macro](https://grafana.com/docs/grafana/latest/datasources/postgres/#macros) results in a significant speedup.

In addition to this, future candidates could be `$__timeFrom()` and `$__timeFrom()`.