### PR TITLE
Insufficient path filtering

### DIFF
--- a/pkg/plugin/check_health.go
+++ b/pkg/plugin/check_health.go
@@ -12,7 +12,7 @@ import (
 )
 
 func checkDB(pathPrefix string, path string, options string) error {
-	if IsPathBlocked(path) {
+	if IsPathBlocked(pathPrefix + path) {
 		return fmt.Errorf("path contains blocked term from GF_PLUGIN_BLOCK_LIST")
 	}
 

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -363,7 +363,7 @@ func query(dataQuery backend.DataQuery, config pluginConfig, ctx context.Context
 	// - Health checks do not prevent saving a datasource configuration in Grafana
 	// - Users can still execute queries even if the health check fails
 	// - This provides runtime protection against accessing blocked paths
-	if IsPathBlocked(config.Path) {
+	if IsPathBlocked(config.PathPrefix + config.Path) {
 		response.Error = fmt.Errorf("path contains blocked term from GF_PLUGIN_BLOCK_LIST")
 		return response
 	}


### PR DESCRIPTION
There was an issue discovered a few months ago in which it was possible to use the sqlite plugin to access the grafana internal DB directly (https://cycode.com/blog/one-plugin-away-breaking-into-grafana-from-the-inside/)
After which a check was added to make sure that no sensitive files paths are passed to the plugin. Though this security check is insufficient since only the path variable is checked without the pathPrefix. This means a user can bypass this check by for example inputting "file:/var/lib/grafana/grafana.db" into the Path Prefix input and leaving the Path input blank, or splitting it up by inputting "file:/var/lib/grafana/grafana" into the Path Prefix field and inputting ".db" into Path.