### PR TITLE
fix: install Playwright browsers in release E2E job

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -100,6 +100,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
       - name: Run Selenium Tests
         env:
           VERBOSE_TEST_OUTPUT: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The following changes are waiting for the next major release:
 
 - supporting only Grafana v10 onwards
 
+## [Unreleased]
+
+### Fixed
+
+- Fix release pipeline: Playwright browsers were not installed in the release E2E job, causing all
+  tests to fail with a missing Chromium binary.
+
 ## [4.0.4] - 2026-05-11
 
 A special thank you to the collaborators on this release:


### PR DESCRIPTION
The release workflow was missing `npx playwright install --with-deps chromium` after `npm ci`, causing all Selenium tests to fail with a missing Chromium binary.